### PR TITLE
Fix: Unused function parameter

### DIFF
--- a/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
+++ b/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
@@ -183,19 +183,19 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface {
     return (3, 2000000, new bytes32[](0));
   }
 
-  function addConsumer(uint64 _subId, address _consumer) external pure override {
+  function addConsumer(uint64 /* _subId */, address /* _consumer */) external pure override {
     revert("not implemented");
   }
 
-  function removeConsumer(uint64 _subId, address _consumer) external pure override {
+  function removeConsumer(uint64 /* _subId */, address /* _consumer */) external pure override {
     revert("not implemented");
   }
 
-  function requestSubscriptionOwnerTransfer(uint64 _subId, address _newOwner) external pure override {
+  function requestSubscriptionOwnerTransfer(uint64 /* _subId */, address /* _newOwner */) external pure override {
     revert("not implemented");
   }
 
-  function acceptSubscriptionOwnerTransfer(uint64 _subId) external pure override {
+  function acceptSubscriptionOwnerTransfer(uint64 /* _subId */) external pure override {
     revert("not implemented");
   }
 }


### PR DESCRIPTION
Warning using `foundry-starter-kit`

```
warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:186:24:
    |
186 |   function addConsumer(uint64 _subId, address _consumer) external pure override {
    |                        ^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:186:39:
    |
186 |   function addConsumer(uint64 _subId, address _consumer) external pure override {
    |                                       ^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:190:27:
    |
190 |   function removeConsumer(uint64 _subId, address _consumer) external pure override {
    |                           ^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:190:42:
    |
190 |   function removeConsumer(uint64 _subId, address _consumer) external pure override {
    |                                          ^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:194:45:
    |
194 |   function requestSubscriptionOwnerTransfer(uint64 _subId, address _newOwner) external pure override {
    |                                             ^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:194:60:
    |
194 |   function requestSubscriptionOwnerTransfer(uint64 _subId, address _newOwner) external pure override {
    |                                                            ^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:198:44:
    |
198 |   function acceptSubscriptionOwnerTransfer(uint64 _subId) external pure override {
    |                                            ^^^^^^^^^^^^^



```