### PR TITLE
Remove existing contracts before copy

### DIFF
--- a/.github/workflows/add-and-commit.yml
+++ b/.github/workflows/add-and-commit.yml
@@ -39,6 +39,7 @@ jobs:
         id: get_updated
         run: |
           yarn upgrade --latest
+          rm -rf contracts/*
           cp -r node_modules/@chainlink/contracts/* contracts/
           jq '.dependencies."@chainlink/contracts"' package.json | sed 's/"//g' | sed 's/\^//g' > version.txt
           version=$(cat version.txt)


### PR DESCRIPTION
Contracts that have been moved to a different directory or renamed between contract releases on the main chainlink repo would exist in both forms here. The fix is simply to wipe out the existing contracts before copying over the new files from the release.