### PR TITLE
Fix remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ forge install smartcontractkit/chainlink-brownie-contracts --no-commit
 
 ```
 remappings = [
-  '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/src/',
+  '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/',
 ]
 ```
 


### PR DESCRIPTION
Errors when running `forge test` while going through Cyfrin Updraft's Foundry Fund Me tutorial when I copy-paste this README's remapping.
Cyfrin Updraft's tutorial remapping is correct.
This commit fix this README's remapping.