### PR TITLE
Update toml remappings in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ forge install smartcontractkit/chainlink-brownie-contracts --no-commit
 
 ```
 remappings = [
-  '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/src/',
+  '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/',
 ]
 ```
 


### PR DESCRIPTION
Update toml remappings in the README.md by removing the 'src/' part as it causes foundry compile error.