### PR TITLE
Remove deprecated --no-commit flag from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Everyday at 3AM, the latest version of the package is updated here, this way, yo
 1. Run this in your projects root directory.
 
 ```bash
-forge install smartcontractkit/chainlink-brownie-contracts --no-commit
+forge install smartcontractkit/chainlink-brownie-contracts
 ```
 
 2. Then, update your `foundry.toml` to include the following in the `remappings`.


### PR DESCRIPTION
This PR fixes issue #50 by removing the outdated `--no-commit` flag from the `forge install` command. Recent versions of Foundry throw an error if this flag is used.

Let me know if you'd like any further tweaks! 🙂
