### PR TITLE
docs: remove deprecated --no-commit flag from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
-
 # Overview
-This repository is a slimmed down version of Chainlink's official repo. It clones *only* the Chainlink `contracts` folder and the repo automatically updates every time there is a new NPM release. 
-
+This repository is a slimmed down version of Chainlink's official repo. It clones *only* the Chainlink `contracts` folder and the repo automatically updates every time there is a new NPM release.
 - NPM's latest release can be found here: https://www.npmjs.com/package/@chainlink/contracts
 - Chainlink's official repo: https://github.com/smartcontractkit/chainlink
 
 # chainlink-brownie-contracts
+A minimal repo that is a copy of the npm package [@chainlink/contracts](https://www.npmjs.com/package/@chainlink/contracts). These contracts are taken from the [core chainlink github](https://github.com/smartcontractkit/chainlink), compressed, and deployed to npm.
 
-A minimal repo that is a copy of the npm package [@chainlink/contracts](https://www.npmjs.com/package/@chainlink/contracts). These contracts are taken from the [core chainlink github](https://github.com/smartcontractkit/chainlink), compressed, and deployed to npm. 
-
-Everyday at 3AM, the latest version of the package is updated here, this way, you can use the Chainlink contracts with foundry without having to use npm/yarn. This also makes other third party packages like Brownie and Ape easier to work with. 
+Everyday at 3AM, the latest version of the package is updated here, this way, you can use the Chainlink contracts with foundry without having to use npm/yarn. This also makes other third party packages like Brownie and Ape easier to work with.
 
 ## Usage
 
 ### Foundry
 
-1. Run this in your projects root directory.
+1. Run this in your project's root directory:
 
 ```bash
-forge install smartcontractkit/chainlink-brownie-contracts --no-commit
+forge install smartcontractkit/chainlink-brownie-contracts
 ```
 
-2. Then, update your `foundry.toml` to include the following in the `remappings`.
+**Note:** The `--no-commit` flag has been removed in recent versions of Foundry since the tool no longer commits automatically. Simply run the command without any flags.
 
-```
+2. Then, update your `foundry.toml` to include the following in the `remappings`:
+
+```toml
 remappings = [
   '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/',
 ]
 ```
 
->! IMPORTANT
-There were compatibility issues with `1.0.0`, `1.1.0` and `1.2.0`, where there were originally 2 versions of each version. We have deleted the deprecated and outdated versions so that there is no longer any conflict. 
+## Versioning
 
-All the releases of this package are going to match the [@chainlink/contracts NPM tags](https://www.npmjs.com/package/@chainlink/contracts). 
+>! IMPORTANT
+>
+> There were compatibility issues with `1.0.0`, `1.1.0` and `1.2.0`, where there were originally 2 versions of each version. We have deleted the deprecated and outdated versions so that there is no longer any conflict.
+
+All the releases of this package are going to match the [@chainlink/contracts NPM tags](https://www.npmjs.com/package/@chainlink/contracts).
+
 So the versioning will look "backwards", but we are starting with v0.2.1


### PR DESCRIPTION
This PR fixes the installation instructions in the README by removing the deprecated `--no-commit` flag that causes errors in current Foundry versions.

**What's the issue?**
The current documentation instructs users to run:
```bash
forge install smartcontractkit/chainlink-brownie-contracts --no-commit
```

This results in an error:
```
error: unexpected argument '--no-commit' found
```

**What changed?**
- Removed `--no-commit` flag from the installation command
- Added a note explaining the flag removal
- Simplified instructions for current Foundry users

**Why?**
Recent Foundry versions removed the `--no-commit` flag because the tool no longer automatically commits installations. The flag is now obsolete and causes the installation to fail.

**Impact:**
Users can now successfully install the package by following the updated documentation without encountering errors.